### PR TITLE
netperfrunner: don't try to wait for ourself, avoid a warning

### DIFF
--- a/netperfrunner.sh
+++ b/netperfrunner.sh
@@ -154,7 +154,7 @@ do
 done
 
 # Wait until each of the background netperf processes completes 
-for i in `pgrep netperf`		# gets a list of PIDs for processes named 'netperf'
+for i in `pgrep netperf -P $$`		# get a list of PIDs for child processes named 'netperf'
 do
 	# echo "Waiting for $i"
 	wait $i


### PR DESCRIPTION
  Warning message:

./netperfrunner.sh: line 162: wait: pid 4736 is not a child of this shell

  Context:

PID: 4736
2015-03-07 17:19:58 Testing netperf-eu.bufferbloat.net (ipv4) with 4 streams down and up while pinging 89.243.96.1. Takes about 30 seconds.
Ping PID: 4741
Starting upload #1 4743
Starting upload #2 4744
Starting upload #3 4745
Starting upload #4 4746
Starting download #1 4748
Starting download #2 4749
Starting download #3 4750
Starting download #4 4751
Waiting for 4736
./netperfrunner.sh: line 162: wait: pid 4736 is not a child of this shell

  Reason:

We used `pgrep netperf`, but the results include the pid of netperfrunner.sh
(substring match).  Also it'd include everybody else's netperf :).

Use `pgrep netperf -P $$` will return exactly the netperf pids
which we can wait for.  (It means --parent, but busybox only supports -P).